### PR TITLE
Add Serverless and WebApp steps to workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,9 +41,6 @@ jobs:
     name: 'Serverless'
     needs: infrastructure
     runs-on: ubuntu-latest
-    strategy:
-    matrix:
-      node-version: ['18.x']
 
     # Required for Github-AWS OIDC to work
     permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,3 +99,42 @@ jobs:
       with:
         args: -c "cd ./services/subreddits && serverless deploy"
         entrypoint: /bin/sh
+
+  webapp:
+    name: 'Web App'
+    needs: services
+    runs-on: ubuntu-latest
+
+    # Required for Github-AWS OIDC to work
+    permissions:
+      id-token: write
+      contents: read
+
+    # Checkout the repository to the GitHub Actions runner
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    # Configure AWS Credentials
+    # Basically run 'aws configure' as you would from local CLI
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: us-east-1
+        role-to-assume: arn:aws:iam::633025216388:role/GithubActions-Fairbanksio-F5oclock
+        role-duration-seconds: 1200 # Optional duration, 20 minutes in this case
+
+    # Install Nodejs
+    - name: Use Node.js 20.x
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20.x
+
+    # Deploy Posts Service
+    - run: npm ci
+      name: "Install dependencies"
+      working-directory: 'webui'
+
+    - run: npm run deploy
+      name: "Deploy"
+      working-directory: 'webui'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
 
     # Install Nodejs
     - name: Use Node.js 20.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 20.x
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,8 +75,8 @@ jobs:
     - name: "Posts Service - Deploy"
       uses: serverless/github-action@v3.2
       with:
-        args: deploy
-      working-directory: 'services/posts'
+        args: -c "cd ./services/posts && serverless deploy"
+        entrypoint: /bin/sh
 
     # Deploy Scraper Service
     - run: npm ci
@@ -86,8 +86,8 @@ jobs:
     - name: "Scraper Service - Deploy"
       uses: serverless/github-action@v3.2
       with:
-        args: deploy
-      working-directory: 'services/scraper'
+        args: -c "cd ./services/scraper && serverless deploy"
+        entrypoint: /bin/sh
 
     # Deploy Subreddits Service
     - run: npm ci
@@ -97,5 +97,5 @@ jobs:
     - name: "Subreddits Service - Deploy"
       uses: serverless/github-action@v3.2
       with:
-        args: deploy
-      working-directory: 'services/subreddits'
+        args: -c "cd ./services/subreddits && serverless deploy"
+        entrypoint: /bin/sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
     # Configure AWS Credentials
     # Basically run 'aws configure' as you would from local CLI
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: us-east-1
         role-to-assume: arn:aws:iam::633025216388:role/GithubActions-Fairbanksio-F5oclock

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - master
-  pull_request:
 
 jobs:
   infrastructure:
@@ -32,10 +31,9 @@ jobs:
       working-directory: 'infrastructure'
       run: terraform fmt -check
 
-    # Run Plan
-    - name: Terraform Plan
-      working-directory: 'infrastructure'
-      run: terraform plan
+    # Build cluster first
+    - name: Terraform Apply
+      run: terraform apply -auto-approve
 
   services:
     name: 'Serverless'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,9 @@ jobs:
     name: 'Serverless'
     needs: infrastructure
     runs-on: ubuntu-latest
+    strategy:
+    matrix:
+      node-version: ['18.x']
 
     # Required for Github-AWS OIDC to work
     permissions:
@@ -60,3 +63,42 @@ jobs:
         aws-region: us-east-1
         role-to-assume: arn:aws:iam::633025216388:role/GithubActions-Fairbanksio-F5oclock
         role-duration-seconds: 1200 # Optional duration, 20 minutes in this case
+
+    # Install Nodejs
+    - name: Use Node.js 20.x
+      uses: actions/setup-node@v3
+      with:
+        node-version: 20.x
+
+    # Deploy Posts Service
+    - run: npm ci
+      name: "Posts Service - Install dependencies"
+      working-directory: 'services/posts'
+
+    - name: "Posts Service - Deploy"
+      uses: serverless/github-action@v3.2
+      with:
+        args: deploy
+      working-directory: 'services/posts'
+
+    # Deploy Scraper Service
+    - run: npm ci
+      name: "Scraper Service - Install dependencies"
+      working-directory: 'services/scraper'
+
+    - name: "Scraper Service - Deploy"
+      uses: serverless/github-action@v3.2
+      with:
+        args: deploy
+      working-directory: 'services/scraper'
+
+    # Deploy Subreddits Service
+    - run: npm ci
+      name: "Subreddits Service - Install dependencies"
+      working-directory: 'services/subreddits'
+
+    - name: "Subreddits Service - Deploy"
+      uses: serverless/github-action@v3.2
+      with:
+        args: deploy
+      working-directory: 'services/subreddits'

--- a/webui/src/Contexts/SubredditContext.js
+++ b/webui/src/Contexts/SubredditContext.js
@@ -53,6 +53,8 @@ export const SubredditProvider = props => {
       : 'https://localhost';
   apiEndpoint = 'https://' + apiEndpoint.replace(/\/$/, '');
 
+  console.log(error)
+
   const fetchSubreddits = () => {
     setLoading(true);
     fetch(apiEndpoint + '/subreddits')


### PR DESCRIPTION
Serverless services have their dependencies installed and deployed one by one, because in order to install serverless plugins that are in use, it requires running an `npm ci` in each service directory anyways and negates half the value of using compose for this. Included WebApp deployment changes here as well. 