### PR TITLE
Keep last successful post body when API returns no data

### DIFF
--- a/webui/src/Components/MainContent.js
+++ b/webui/src/Components/MainContent.js
@@ -43,6 +43,34 @@ const findLatestFetch = posts => {
   return latestFetch;
 };
 
+const getValidatedPosts = json => {
+  if (!json || !Array.isArray(json.data)) {
+    throw new Error('Invalid posts payload');
+  }
+
+  return json.data;
+};
+
+const logDelayedPosts = (subreddit, posts) => {
+  const latestFetch = findLatestFetch(posts);
+  const latestFetchIso = latestFetch ? new Date(latestFetch).toISOString() : null;
+
+  console.warn('Posts look stale relative to the expected refresh window.', {
+    subreddit,
+    postCount: posts.length,
+    latestFetchedAt: latestFetchIso,
+    expectedFreshWithinSeconds: 120,
+  });
+};
+
+const logPostFetchFailure = (error, subreddit) => {
+  console.error('Failed to refresh posts. Keeping the last successful results until the next valid response.', {
+    subreddit,
+    error: error.message,
+    endpoint: apiEndpoint + '/posts/' + subreddit.replace(/\+/g, '%2b'),
+  });
+};
+
 const PostView = () => {
   const isVisible = usePageVisibility();
   const { refreshInterval } = useContext(RefreshIntervalContext);
@@ -69,28 +97,28 @@ const PostView = () => {
   const fetchPosts = () => {
     setLoading(true);
     fetch(apiEndpoint + '/posts/' + subreddit.replace(/\+/g, '%2b'))
-      .then(response => response.json())
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(`Failed to fetch posts: ${response.status}`);
+        }
+
+        return response.json();
+      })
       .then(json => {
-        setPosts(json.data);
+        const nextPosts = getValidatedPosts(json);
+        setPosts(nextPosts);
+        setError({ show: false });
+
         setTimeout(() => {
           setLoading(false);
         }, 1700);
-        setError({ show: false });
-        
-        if (gtThan5MinsAgo(findLatestFetch(json.data))) {
-          console.log('delayed');
-          /*
-          setError({
-            level: 'warning',
-            show: true,
-            title: 'Delayed Posts:',
-            message:
-              "Content may be out of date.. This may be due to Reddit's API experiencing issues.",
-          });
-          */
+
+        if (nextPosts.length > 0 && gtThan5MinsAgo(findLatestFetch(nextPosts))) {
+          logDelayedPosts(subreddit, nextPosts);
         }
       })
       .catch(error => {
+        logPostFetchFailure(error, subreddit);
         setError({
           level: 'error',
           show: true,

--- a/webui/src/Components/MainContent.test.js
+++ b/webui/src/Components/MainContent.test.js
@@ -1,0 +1,148 @@
+import React from 'react';
+import { act, screen, waitFor } from '@testing-library/react';
+import { render } from '../test-utils';
+import MainContent from './MainContent';
+import { RefreshIntervalContext } from '../Contexts/RefreshIntervalContext';
+import { SubredditContext } from '../Contexts/SubredditContext';
+import { ViewModeContext } from '../Contexts/ViewModeContext';
+import { LoadingContext } from '../Contexts/LoadingContext';
+const { matchMedia } = require('mock-match-media');
+
+jest.mock('react-page-visibility', () => ({
+  usePageVisibility: () => true,
+}));
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: matchMedia,
+});
+
+const renderMainContent = () =>
+  render(
+    <LoadingContext.Provider value={{ loading: false, setLoading: jest.fn() }}>
+      <RefreshIntervalContext.Provider
+        value={{ refreshInterval: 1, setRefreshInterval: jest.fn() }}
+      >
+        <SubredditContext.Provider
+          value={{
+            subreddit: 'politics',
+            subredditList: ['politics'],
+            setSubreddit: jest.fn(),
+          }}
+        >
+          <ViewModeContext.Provider
+            value={{ viewMode: 'list', setViewMode: jest.fn() }}
+          >
+            <MainContent />
+          </ViewModeContext.Provider>
+        </SubredditContext.Provider>
+      </RefreshIntervalContext.Provider>
+    </LoadingContext.Provider>
+  );
+
+describe('MainContent', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    jest.resetAllMocks();
+  });
+
+  test('clears posts when a refresh returns a valid empty response', async () => {
+    const post = {
+      title: 'Existing headline',
+      url: 'https://example.com/story',
+      commentCount: 12,
+      upvoteCount: 42,
+      created_utc: Math.floor(Date.now() / 1000),
+      domain: 'example.com',
+      commentLink: '/r/politics/comments/abc123/example',
+    };
+
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: [post] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: [] }),
+      });
+
+    await act(async () => {
+      renderMainContent();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Existing headline')).toBeInTheDocument();
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Existing headline')).not.toBeInTheDocument();
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('keeps the last successful posts when a refresh payload is invalid', async () => {
+    const post = {
+      title: 'Existing headline',
+      url: 'https://example.com/story',
+      commentCount: 12,
+      upvoteCount: 42,
+      created_utc: Math.floor(Date.now() / 1000),
+      domain: 'example.com',
+      commentLink: '/r/politics/comments/abc123/example',
+    };
+
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: [post] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ nope: true }),
+      });
+
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    await act(async () => {
+      renderMainContent();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Existing headline')).toBeInTheDocument();
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('There was a problem fetching new posts. Retrying..')
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Existing headline')).toBeInTheDocument();
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/webui/src/Contexts/SubredditContext.js
+++ b/webui/src/Contexts/SubredditContext.js
@@ -53,12 +53,16 @@ export const SubredditProvider = props => {
       : 'https://localhost';
   apiEndpoint = 'https://' + apiEndpoint.replace(/\/$/, '');
 
-  console.log(error)
-
   const fetchSubreddits = () => {
     setLoading(true);
     fetch(apiEndpoint + '/subreddits')
-      .then(response => response.json())
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(`Failed to fetch subreddits: ${response.status}`);
+        }
+
+        return response.json();
+      })
       .then(json => {
         setSubredditList(
           json.data.sort(function (a, b) {
@@ -71,11 +75,15 @@ export const SubredditProvider = props => {
         setError({ show: false });
       })
       .catch(error => {
+        console.error('Failed to refresh subreddit list.', {
+          error: error.message,
+          endpoint: apiEndpoint + '/subreddits',
+        });
         setError({
           level: 'error',
           show: true,
           title: 'Ooops:',
-          message: 'There was a problem fetching new posts. Retrying..',
+          message: 'There was a problem fetching subreddits. Retrying..',
         });
         setLoading(false);
       });


### PR DESCRIPTION
This pull request improves error handling and robustness for fetching posts and subreddits in the main content component. It adds input validation, more informative logging, and new tests to ensure correct behavior when API responses are empty or invalid. The most important changes are:

**Enhanced error handling and validation:**

* Added a `getValidatedPosts` function to ensure the posts payload is valid before updating state, and improved error handling in the `fetchPosts` function of `MainContent.js`. This prevents invalid data from causing UI issues and logs errors more clearly. [[1]](diffhunk://#diff-8038f094f83e937e0e243bd7cf1c568c4fef1f8b481018f29d98f65b6f8e6acaR46-R73) [[2]](diffhunk://#diff-8038f094f83e937e0e243bd7cf1c568c4fef1f8b481018f29d98f65b6f8e6acaL72-R121)
* Updated subreddit fetching logic in `SubredditContext.js` to check for HTTP errors, log failures with context, and show a more accurate error message. [[1]](diffhunk://#diff-53dac91b93a1a4f57ddc0463a0f99f9d607331987c9627b001300d6fba5b79abL56-R65) [[2]](diffhunk://#diff-53dac91b93a1a4f57ddc0463a0f99f9d607331987c9627b001300d6fba5b79abR78-R86)

**Improved logging for debugging:**

* Added `logDelayedPosts` and `logPostFetchFailure` helpers to `MainContent.js` to provide structured warnings when posts are stale or fetches fail, aiding in diagnosing API or data issues. [[1]](diffhunk://#diff-8038f094f83e937e0e243bd7cf1c568c4fef1f8b481018f29d98f65b6f8e6acaR46-R73) [[2]](diffhunk://#diff-8038f094f83e937e0e243bd7cf1c568c4fef1f8b481018f29d98f65b6f8e6acaL72-R121)

**Expanded test coverage:**

* Added comprehensive tests in `MainContent.test.js` to verify that posts are cleared on a valid empty response, and that the last successful posts are retained when the payload is invalid, ensuring correct UI behavior in edge cases.