### PR TITLE
Improve Reddit preview image quality

### DIFF
--- a/services/scraper/imageSource.js
+++ b/services/scraper/imageSource.js
@@ -456,10 +456,6 @@ const fetchArticleImage = async (url, options = {}) => {
 };
 
 const redditImageSource = (data) => {
-  if (hasUsableThumbnail(data.thumbnail)) {
-    return data.thumbnail.replace(/amp;/g, "");
-  }
-
   if (data.preview) {
     if (data.preview.images) {
       if (data.preview.images.length > 0) {
@@ -484,6 +480,10 @@ const redditImageSource = (data) => {
         }
       }
     }
+  }
+
+  if (hasUsableThumbnail(data.thumbnail)) {
+    return data.thumbnail.replace(/amp;/g, "");
   }
 
   return "";

--- a/services/scraper/imageSource.test.js
+++ b/services/scraper/imageSource.test.js
@@ -478,6 +478,35 @@ test("fetchArticleImage tolerates early-return responses without bodies", async 
   assert.equal(image, "");
 });
 
+test("imageSource uses Reddit preview image before low-resolution thumbnail", async () => {
+  const image = await imageSource(
+    {
+      thumbnail:
+        "https://external-preview.redd.it/story.jpeg?width=140&height=93&auto=webp",
+      preview: {
+        images: [
+          {
+            source: {
+              url: "https://external-preview.redd.it/story.jpeg?auto=webp&amp;s=fullsize",
+            },
+          },
+        ],
+      },
+      url: "https://publisher.example/story",
+    },
+    {
+      fetchArticleImageImpl: async () => {
+        throw new Error("article metadata should not be fetched");
+      },
+    }
+  );
+
+  assert.equal(
+    image,
+    "https://external-preview.redd.it/story.jpeg?auto=webp&s=fullsize"
+  );
+});
+
 test("imageSource uses Reddit thumbnail before article metadata fallback", async () => {
   const image = await imageSource(
     {


### PR DESCRIPTION
## Summary
- Prefer higher-resolution Reddit preview/gallery images before low-resolution thumbnail URLs in the scraper
- Add a regression test for preview URLs winning over 140px thumbnail URLs

## Validation
- npm run lint in services/scraper
- npm test in services/scraper