### PR TITLE
chore: clean up scraper assignments for ESLint 10

### DIFF
--- a/services/scraper/imageSource.js
+++ b/services/scraper/imageSource.js
@@ -502,14 +502,12 @@ const imageSource = async (data, options = {}) => {
 
   const fetchArticleImageImpl =
     options.fetchArticleImageImpl || fetchArticleImage;
-  let articleImage = "";
   try {
-    articleImage = await fetchArticleImageImpl(articleUrl, options);
+    const articleImage = await fetchArticleImageImpl(articleUrl, options);
+    return articleImage || data.thumbnail || "";
   } catch (error) {
-    articleImage = "";
+    return data.thumbnail || "";
   }
-
-  return articleImage || data.thumbnail || "";
 };
 
 module.exports = {

--- a/services/scraper/index.js
+++ b/services/scraper/index.js
@@ -15,9 +15,8 @@ const insertNewPosts = (
   { imageSourceImpl = imageSource, logger = console, newPostModel = newPost } = {}
 ) => {
   logger.log("inserting new posts:", newPosts);
-  let insertPromises = [];
   // Fill array with promises
-  insertPromises = mapWithConcurrency(
+  const insertPromises = mapWithConcurrency(
     newPosts,
     IMAGE_SOURCE_CONCURRENCY,
     async (value) => {
@@ -78,13 +77,9 @@ const insertNewPosts = (
     }
   );
 
-  return insertPromises
-    .catch((e) => {
-      logger.warn(`Error Inserting Posts @ ${Date.now()}: ${e}`);
-    })
-    .finally(() => {
-      insertPromises = null;
-    });
+  return insertPromises.catch((e) => {
+    logger.warn(`Error Inserting Posts @ ${Date.now()}: ${e}`);
+  });
 };
 
 const createFetchPosts = ({


### PR DESCRIPTION
## Summary
- remove placeholder/reassignment patterns flagged by ESLint 10 recommended rules in the scraper
- keep scraper image fallback behavior the same

## Validation
- npm run lint (services/scraper)
- npm test (services/scraper)