### PR TITLE
chore: add scraper yaml test dependency

### DIFF
--- a/services/scraper/package-lock.json
+++ b/services/scraper/package-lock.json
@@ -17,6 +17,7 @@
         "@eslint/js": "^8.57.1",
         "eslint": "^8.57.1",
         "globals": "^17.6.0",
+        "js-yaml": "^4.2.0",
         "nodemon": "^3.1.14",
         "serverless": "^4.36.1"
       },
@@ -939,10 +940,20 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/services/scraper/package.json
+++ b/services/scraper/package.json
@@ -15,6 +15,7 @@
     "@eslint/js": "^8.57.1",
     "eslint": "^8.57.1",
     "globals": "^17.6.0",
+    "js-yaml": "^4.2.0",
     "nodemon": "^3.1.14",
     "serverless": "^4.36.1"
   },


### PR DESCRIPTION
## Summary
- add js-yaml as an explicit scraper dev dependency because serverless.test.js imports it directly
- avoid relying on Serverless transitive dependencies after the Serverless 4 Dependabot bump

## Validation
- npm run lint (services/scraper)
- npm test (services/scraper)