### PR TITLE
chore: remove react-page-visibility dependency

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -18,7 +18,6 @@
         "react-dom": "^17.0.2",
         "react-ga4": "^1.4.1",
         "react-icons": "^3.11.0",
-        "react-page-visibility": "^6.4.0",
         "react-player": "^2.16.1",
         "react-router-dom": "^6.30.3"
       },
@@ -5390,20 +5389,6 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
-    "node_modules/react-page-visibility": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/react-page-visibility/-/react-page-visibility-6.4.0.tgz",
-      "integrity": "sha512-5vQ0zQU2DvKCQAxle9l5V6uxw2m180Lk7Jem+obmTeQ503fvMJLSUzFgWtTEgUVynhUx2pd+RzafnuMAG8uD6A==",
-      "dependencies": {
-        "prop-types": "^15.7.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^16.13.1 || ^17.0.0"
-      }
-    },
     "node_modules/react-player": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/react-player/-/react-player-2.16.1.tgz",
@@ -10167,14 +10152,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
-    },
-    "react-page-visibility": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/react-page-visibility/-/react-page-visibility-6.4.0.tgz",
-      "integrity": "sha512-5vQ0zQU2DvKCQAxle9l5V6uxw2m180Lk7Jem+obmTeQ503fvMJLSUzFgWtTEgUVynhUx2pd+RzafnuMAG8uD6A==",
-      "requires": {
-        "prop-types": "^15.7.2"
-      }
     },
     "react-player": {
       "version": "2.16.1",

--- a/webui/package.json
+++ b/webui/package.json
@@ -16,7 +16,6 @@
     "react-dom": "^17.0.2",
     "react-ga4": "^1.4.1",
     "react-icons": "^3.11.0",
-    "react-page-visibility": "^6.4.0",
     "react-player": "^2.16.1",
     "react-router-dom": "^6.30.3"
   },

--- a/webui/src/Components/MainContent.jsx
+++ b/webui/src/Components/MainContent.jsx
@@ -15,7 +15,7 @@ import { ViewModeContext } from '../Contexts/ViewModeContext';
 import { LoadingContext } from '../Contexts/LoadingContext';
 import GridView from './GridView';
 import ListView from './ListView';
-import { usePageVisibility } from 'react-page-visibility';
+import usePageVisibility from '../Util/usePageVisibility';
 import { getRuntimeConfigValue, normalizeApiEndpoint } from '../runtimeConfig';
 
 const apiEndpoint = normalizeApiEndpoint(getRuntimeConfigValue('REACT_APP_API') || 'https://localhost');

--- a/webui/src/Components/MainContent.test.jsx
+++ b/webui/src/Components/MainContent.test.jsx
@@ -8,10 +8,6 @@ import { ViewModeContext } from '../Contexts/ViewModeContext';
 import { LoadingContext } from '../Contexts/LoadingContext';
 const { matchMedia } = require('mock-match-media');
 
-vi.mock('react-page-visibility', () => ({
-  usePageVisibility: () => true,
-}));
-
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
   value: matchMedia,

--- a/webui/src/Util/usePageVisibility.js
+++ b/webui/src/Util/usePageVisibility.js
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+
+const getIsPageVisible = () => {
+  if (typeof document === 'undefined' || !document.visibilityState) {
+    return true;
+  }
+
+  return document.visibilityState === 'visible';
+};
+
+const usePageVisibility = () => {
+  const [isVisible, setIsVisible] = useState(getIsPageVisible);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return undefined;
+    }
+
+    const handleVisibilityChange = () => {
+      setIsVisible(getIsPageVisible());
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, []);
+
+  return isVisible;
+};
+
+export default usePageVisibility;


### PR DESCRIPTION
## Summary
- replace react-page-visibility with a local Page Visibility API hook
- remove the package and lockfile entries
- remove the now-unneeded MainContent test mock

## Validation
- npm run lint (webui)
- npm test (webui)