### PR TITLE
Deploy scraper image backfill metrics

### DIFF
--- a/services/scraper/index.js
+++ b/services/scraper/index.js
@@ -8,9 +8,215 @@ const {
 } = require("./imageSource");
 
 const IMAGE_SOURCE_CONCURRENCY = 10;
+const IMAGE_METRIC_NAMESPACE = "F5News/Scraper";
+const IMAGE_BACKFILL_CONCURRENCY = 5;
+const IMAGE_BACKFILL_LIMIT = 25;
+const IMAGE_BACKFILL_LOOKBACK_SECONDS = 8 * 60 * 60;
 
 const fetch = (...args) =>
   import("node-fetch").then(({ default: fetchImpl }) => fetchImpl(...args));
+
+const getPostDomain = (data) => data.domain || "unknown";
+
+const getPostId = (data) => {
+  if (data.id || data.name) {
+    return data.id || data.name;
+  }
+
+  if (data._id) {
+    return data._id.toString ? data._id.toString() : String(data._id);
+  }
+
+  return "";
+};
+
+const getPostUrl = (data) => data.url_overridden_by_dest || data.url || "";
+
+const shouldTrackImageResolution = (data) => {
+  return !data.is_self && !data.is_video && Boolean(getPostUrl(data));
+};
+
+const logStructured = (logger, payload) => {
+  logger.log(JSON.stringify(payload));
+};
+
+const createImageResolutionMetrics = (subreddit, operation) => ({
+  subreddit,
+  operation,
+  attempts: 0,
+  resolved: 0,
+  missing: 0,
+  errors: 0,
+});
+
+const logImageResolutionMetrics = (logger, metrics) => {
+  if (metrics.attempts === 0) {
+    return;
+  }
+
+  logStructured(logger, {
+    _aws: {
+      Timestamp: Date.now(),
+      CloudWatchMetrics: [
+        {
+          Namespace: IMAGE_METRIC_NAMESPACE,
+          Dimensions: [["Service", "Subreddit", "Operation"]],
+          Metrics: [
+            {
+              Name: "PostImageResolutionAttempts",
+              Unit: "Count",
+            },
+            {
+              Name: "PostImageResolutionResolved",
+              Unit: "Count",
+            },
+            {
+              Name: "PostImageResolutionMissing",
+              Unit: "Count",
+            },
+            {
+              Name: "PostImageResolutionErrors",
+              Unit: "Count",
+            },
+          ],
+        },
+      ],
+    },
+    Service: "scraper",
+    Subreddit: metrics.subreddit,
+    Operation: metrics.operation,
+    PostImageResolutionAttempts: metrics.attempts,
+    PostImageResolutionResolved: metrics.resolved,
+    PostImageResolutionMissing: metrics.missing,
+    PostImageResolutionErrors: metrics.errors,
+  });
+};
+
+const createPostKey = (data) => ({
+  title: data.title,
+  author: data.author,
+  created_utc: data.created_utc,
+});
+
+const missingThumbnailFilter = () => ({
+  $or: [
+    { thumbnail: { $exists: false } },
+    { thumbnail: null },
+    { thumbnail: "" },
+    { thumbnail: { $in: ["default", "self", "spoiler", "nsfw", "image"] } },
+  ],
+});
+
+const findMissingThumbnailPosts = async (
+  newPostModel,
+  subreddit,
+  { now = () => new Date(), lookbackSeconds = IMAGE_BACKFILL_LOOKBACK_SECONDS } = {}
+) => {
+  const createdAfter = Math.floor(now().getTime() / 1000) - lookbackSeconds;
+  let query = newPostModel.find({
+    sub: subreddit,
+    created_utc: { $gt: createdAfter },
+    is_self: { $ne: true },
+    is_video: { $ne: true },
+    url: { $exists: true, $ne: "" },
+    ...missingThumbnailFilter(),
+  });
+
+  if (typeof query.sort === "function") {
+    query = query.sort({ created_utc: -1 });
+  }
+
+  if (typeof query.limit === "function") {
+    query = query.limit(IMAGE_BACKFILL_LIMIT);
+  }
+
+  return query;
+};
+
+const updatePostThumbnail = (newPostModel, data, thumbnail) => {
+  const postKey = data._id ? { _id: data._id } : createPostKey(data);
+
+  return newPostModel.findOneAndUpdate(
+    postKey,
+    { $set: { thumbnail } },
+    { upsert: false }
+  );
+};
+
+const backfillMissingPostImages = async (
+  subreddit,
+  {
+    imageSourceImpl = imageSource,
+    logger = console,
+    newPostModel = newPost,
+    now = () => new Date(),
+  } = {}
+) => {
+  const imageMetrics = createImageResolutionMetrics(subreddit, "backfill");
+  let posts;
+
+  try {
+    posts = await findMissingThumbnailPosts(newPostModel, subreddit, { now });
+  } catch (error) {
+    logger.warn(`Error finding posts missing images @ ${Date.now()}: ${error}`);
+    return;
+  }
+
+  await mapWithConcurrency(
+    posts || [],
+    IMAGE_BACKFILL_CONCURRENCY,
+    async (post) => {
+      if (!shouldTrackImageResolution(post)) {
+        return;
+      }
+
+      imageMetrics.attempts += 1;
+      let thumbnail = "";
+
+      try {
+        thumbnail = await imageSourceImpl(post);
+      } catch (error) {
+        imageMetrics.errors += 1;
+        logStructured(logger, {
+          eventType: "POST_IMAGE_BACKFILL_ERROR",
+          subreddit,
+          domain: getPostDomain(post),
+          postId: getPostId(post),
+          postUrl: getPostUrl(post),
+          title: post.title,
+          errorMessage: error.message,
+        });
+      }
+
+      if (hasUsableThumbnail(thumbnail)) {
+        imageMetrics.resolved += 1;
+        await updatePostThumbnail(newPostModel, post, thumbnail);
+        logStructured(logger, {
+          eventType: "POST_IMAGE_BACKFILL_RESOLVED",
+          subreddit,
+          domain: getPostDomain(post),
+          postId: getPostId(post),
+          postUrl: getPostUrl(post),
+          title: post.title,
+        });
+        return;
+      }
+
+      imageMetrics.missing += 1;
+      logStructured(logger, {
+        eventType: "POST_IMAGE_BACKFILL_MISSING",
+        subreddit,
+        domain: getPostDomain(post),
+        postId: getPostId(post),
+        postUrl: getPostUrl(post),
+        title: post.title,
+        redditThumbnail: post.thumbnail || "",
+      });
+    }
+  );
+
+  logImageResolutionMetrics(logger, imageMetrics);
+};
 
 const insertNewPosts = (
   newPosts,
@@ -18,6 +224,7 @@ const insertNewPosts = (
   { imageSourceImpl = imageSource, logger = console, newPostModel = newPost } = {}
 ) => {
   logger.log("inserting new posts:", newPosts);
+  const imageMetrics = createImageResolutionMetrics(subreddit, "scrape");
   // Fill array with promises
   const insertPromises = mapWithConcurrency(
     newPosts,
@@ -49,11 +256,12 @@ const insertNewPosts = (
         },
       };
 
-      const postKey = {
-        title: value.data.title,
-        author: value.data.author,
-        created_utc: value.data.created_utc,
-      };
+      const postKey = createPostKey(value.data);
+      const trackImageResolution = shouldTrackImageResolution(value.data);
+
+      if (trackImageResolution) {
+        imageMetrics.attempts += 1;
+      }
 
       await newPostModel.findOneAndUpdate(postKey, postUpdate, { upsert: true });
 
@@ -61,6 +269,18 @@ const insertNewPosts = (
       try {
         thumbnail = await imageSourceImpl(value.data);
       } catch (error) {
+        if (trackImageResolution) {
+          imageMetrics.errors += 1;
+          logStructured(logger, {
+            eventType: "POST_IMAGE_RESOLUTION_ERROR",
+            subreddit,
+            domain: getPostDomain(value.data),
+            postId: getPostId(value.data),
+            postUrl: getPostUrl(value.data),
+            title: value.data.title,
+            errorMessage: error.message,
+          });
+        }
         logger.warn(
           `Error resolving post image source @ ${Date.now()}: ${error}`
         );
@@ -69,20 +289,38 @@ const insertNewPosts = (
       const hasResolvedThumbnail = hasUsableThumbnail(thumbnail);
 
       if (hasResolvedThumbnail) {
-        return newPostModel.findOneAndUpdate(
-          postKey,
-          { $set: { thumbnail } },
-          { upsert: false }
-        );
+        if (trackImageResolution) {
+          imageMetrics.resolved += 1;
+        }
+        return updatePostThumbnail(newPostModel, value.data, thumbnail);
+      }
+
+      if (trackImageResolution) {
+        imageMetrics.missing += 1;
+        logStructured(logger, {
+          eventType: "POST_IMAGE_RESOLUTION_MISSING",
+          subreddit,
+          domain: getPostDomain(value.data),
+          postId: getPostId(value.data),
+          postUrl: getPostUrl(value.data),
+          title: value.data.title,
+          redditThumbnail: value.data.thumbnail || "",
+        });
       }
 
       return null;
     }
   );
 
-  return insertPromises.catch((e) => {
-    logger.warn(`Error Inserting Posts @ ${Date.now()}: ${e}`);
-  });
+  return insertPromises
+    .then((result) => {
+      logImageResolutionMetrics(logger, imageMetrics);
+      return result;
+    })
+    .catch((e) => {
+      logger.warn(`Error Inserting Posts @ ${Date.now()}: ${e}`);
+      logImageResolutionMetrics(logger, imageMetrics);
+    });
 };
 
 const createFetchPosts = ({
@@ -92,6 +330,7 @@ const createFetchPosts = ({
   logger = console,
   mongooseClient = mongoose,
   newPostModel = newPost,
+  now = () => new Date(),
 } = {}) => {
   const normalizedFetch = normalizeFetch(fetchImpl);
 
@@ -164,6 +403,14 @@ const createFetchPosts = ({
         });
       })
       .then(() => {
+        return backfillMissingPostImages(subreddit, {
+          imageSourceImpl,
+          logger,
+          newPostModel,
+          now,
+        });
+      })
+      .then(() => {
         logger.log(`Saved New Posts @ ${Date.now()}`);
         logger.log(
           `Currently using ${(
@@ -180,4 +427,8 @@ const createFetchPosts = ({
 };
 
 module.exports.createFetchPosts = createFetchPosts;
+module.exports.createImageResolutionMetrics = createImageResolutionMetrics;
+module.exports.backfillMissingPostImages = backfillMissingPostImages;
+module.exports.findMissingThumbnailPosts = findMissingThumbnailPosts;
 module.exports.fetchPosts = createFetchPosts();
+module.exports.logImageResolutionMetrics = logImageResolutionMetrics;

--- a/services/scraper/index.test.js
+++ b/services/scraper/index.test.js
@@ -1,7 +1,7 @@
 const assert = require("assert");
 const test = require("node:test");
 
-const { createFetchPosts } = require("./index");
+const { backfillMissingPostImages, createFetchPosts } = require("./index");
 
 const createFetcher = ({ accessToken = "token", posts = [] } = {}) => {
   const calls = [];
@@ -27,9 +27,31 @@ const createFetcher = ({ accessToken = "token", posts = [] } = {}) => {
 };
 
 const createLogger = () => ({
-  log: () => {},
-  warn: () => {},
+  logs: [],
+  warnings: [],
+  log(...args) {
+    this.logs.push(args);
+  },
+  warn(...args) {
+    this.warnings.push(args);
+  },
 });
+
+const parseStructuredLogs = (logger, eventType) => {
+  return logger.logs
+    .map((args) => {
+      if (args.length !== 1 || typeof args[0] !== "string") {
+        return null;
+      }
+
+      try {
+        return JSON.parse(args[0]);
+      } catch (error) {
+        return null;
+      }
+    })
+    .filter((entry) => entry && (!eventType || entry.eventType === eventType));
+};
 
 const createDeferred = () => {
   let resolve;
@@ -328,6 +350,323 @@ test("fetchPosts creates brand-new external posts even when thumbnails are missi
   assert.equal(writes.length, 1);
   assert.equal(writes[0][1].$set.thumbnail, undefined);
   assert.deepEqual(writes[0][2], { upsert: true });
+});
+
+test("fetchPosts logs missing article image metrics for graphing", async () => {
+  const posts = [
+    {
+      data: {
+        id: "post1",
+        title: "Reuters Story",
+        author: "author",
+        created_utc: 1710000000,
+        thumbnail: "",
+        domain: "reuters.com",
+        url: "https://www.reuters.com/world/story",
+        permalink: "/r/news/comments/story",
+        ups: 42,
+        num_comments: 7,
+        post_hint: "link",
+        is_video: false,
+        media: null,
+        is_gallery: false,
+        gallery_data: null,
+        media_metadata: null,
+        is_self: false,
+        selftext: "",
+        selftext_html: null,
+        upvote_ratio: 0.91,
+        rpan_video: null,
+      },
+    },
+  ];
+  const { fetchImpl } = createFetcher({ posts });
+  const logger = createLogger();
+  const handler = createFetchPosts({
+    fetchImpl,
+    imageSourceImpl: async () => "",
+    logger,
+    mongooseClient: {
+      connect: async () => {},
+    },
+    newPostModel: {
+      findOneAndUpdate: async () => {},
+    },
+  });
+
+  await handler({ subreddit: "news" });
+
+  const missingLogs = parseStructuredLogs(
+    logger,
+    "POST_IMAGE_RESOLUTION_MISSING"
+  );
+  assert.equal(missingLogs.length, 1);
+  assert.deepEqual(missingLogs[0], {
+    eventType: "POST_IMAGE_RESOLUTION_MISSING",
+    subreddit: "news",
+    domain: "reuters.com",
+    postId: "post1",
+    postUrl: "https://www.reuters.com/world/story",
+    title: "Reuters Story",
+    redditThumbnail: "",
+  });
+
+  const metricLog = parseStructuredLogs(logger).find((entry) => entry._aws);
+  assert.equal(metricLog.Service, "scraper");
+  assert.equal(metricLog.Subreddit, "news");
+  assert.equal(metricLog.Operation, "scrape");
+  assert.equal(metricLog.PostImageResolutionAttempts, 1);
+  assert.equal(metricLog.PostImageResolutionResolved, 0);
+  assert.equal(metricLog.PostImageResolutionMissing, 1);
+  assert.equal(metricLog.PostImageResolutionErrors, 0);
+  assert.equal(
+    metricLog._aws.CloudWatchMetrics[0].Namespace,
+    "F5News/Scraper"
+  );
+});
+
+test("fetchPosts logs image resolution errors separately from missing thumbnails", async () => {
+  const posts = [
+    {
+      data: {
+        name: "t3_post2",
+        title: "Blocked Publisher Story",
+        author: "author",
+        created_utc: 1710000000,
+        thumbnail: "",
+        domain: "publisher.example",
+        url: "https://publisher.example/story",
+        permalink: "/r/news/comments/story",
+        ups: 42,
+        num_comments: 7,
+        post_hint: "link",
+        is_video: false,
+        media: null,
+        is_gallery: false,
+        gallery_data: null,
+        media_metadata: null,
+        is_self: false,
+        selftext: "",
+        selftext_html: null,
+        upvote_ratio: 0.91,
+        rpan_video: null,
+      },
+    },
+  ];
+  const { fetchImpl } = createFetcher({ posts });
+  const logger = createLogger();
+  const handler = createFetchPosts({
+    fetchImpl,
+    imageSourceImpl: async () => {
+      throw new Error("publisher blocked metadata fetch");
+    },
+    logger,
+    mongooseClient: {
+      connect: async () => {},
+    },
+    newPostModel: {
+      findOneAndUpdate: async () => {},
+    },
+  });
+
+  await handler({ subreddit: "news" });
+
+  const errorLogs = parseStructuredLogs(
+    logger,
+    "POST_IMAGE_RESOLUTION_ERROR"
+  );
+  assert.equal(errorLogs.length, 1);
+  assert.deepEqual(errorLogs[0], {
+    eventType: "POST_IMAGE_RESOLUTION_ERROR",
+    subreddit: "news",
+    domain: "publisher.example",
+    postId: "t3_post2",
+    postUrl: "https://publisher.example/story",
+    title: "Blocked Publisher Story",
+    errorMessage: "publisher blocked metadata fetch",
+  });
+
+  const metricLog = parseStructuredLogs(logger).find((entry) => entry._aws);
+  assert.equal(metricLog.Operation, "scrape");
+  assert.equal(metricLog.PostImageResolutionAttempts, 1);
+  assert.equal(metricLog.PostImageResolutionResolved, 0);
+  assert.equal(metricLog.PostImageResolutionMissing, 1);
+  assert.equal(metricLog.PostImageResolutionErrors, 1);
+});
+
+test("fetchPosts backfills recent posts with missing thumbnails", async () => {
+  const posts = [];
+  const { fetchImpl } = createFetcher({ posts });
+  const logger = createLogger();
+  const writes = [];
+  const findCalls = [];
+  const recentMissingPost = {
+    _id: "mongo-id-1",
+    title: "Reuters Story",
+    author: "author",
+    created_utc: 1710000000,
+    thumbnail: "",
+    domain: "reuters.com",
+    url: "https://www.reuters.com/world/story",
+    sub: "news",
+    is_self: false,
+    is_video: false,
+  };
+  const query = {
+    sortArgs: null,
+    limitArg: null,
+    sort(args) {
+      this.sortArgs = args;
+      return this;
+    },
+    limit(arg) {
+      this.limitArg = arg;
+      return this;
+    },
+    then(resolve) {
+      return Promise.resolve([recentMissingPost]).then(resolve);
+    },
+  };
+  const handler = createFetchPosts({
+    fetchImpl,
+    imageSourceImpl: async (post) =>
+      post.url.includes("reuters.com") ? "https://cdn.example.com/reuters.jpg" : "",
+    logger,
+    mongooseClient: {
+      connect: async () => {},
+    },
+    newPostModel: {
+      find: (args) => {
+        findCalls.push(args);
+        return query;
+      },
+      findOneAndUpdate: async (...args) => {
+        writes.push(args);
+      },
+    },
+    now: () => new Date("2024-03-10T12:00:00Z"),
+  });
+
+  await handler({ subreddit: "news" });
+
+  assert.equal(findCalls.length, 1);
+  assert.deepEqual(findCalls[0], {
+    sub: "news",
+    created_utc: { $gt: 1710043200 },
+    is_self: { $ne: true },
+    is_video: { $ne: true },
+    url: { $exists: true, $ne: "" },
+    $or: [
+      { thumbnail: { $exists: false } },
+      { thumbnail: null },
+      { thumbnail: "" },
+      { thumbnail: { $in: ["default", "self", "spoiler", "nsfw", "image"] } },
+    ],
+  });
+  assert.deepEqual(query.sortArgs, { created_utc: -1 });
+  assert.equal(query.limitArg, 25);
+  assert.equal(writes.length, 1);
+  assert.deepEqual(writes[0], [
+    { _id: "mongo-id-1" },
+    { $set: { thumbnail: "https://cdn.example.com/reuters.jpg" } },
+    { upsert: false },
+  ]);
+
+  const resolvedLogs = parseStructuredLogs(
+    logger,
+    "POST_IMAGE_BACKFILL_RESOLVED"
+  );
+  assert.equal(resolvedLogs.length, 1);
+  assert.deepEqual(resolvedLogs[0], {
+    eventType: "POST_IMAGE_BACKFILL_RESOLVED",
+    subreddit: "news",
+    domain: "reuters.com",
+    postId: "mongo-id-1",
+    postUrl: "https://www.reuters.com/world/story",
+    title: "Reuters Story",
+  });
+
+  const metricLog = parseStructuredLogs(logger).find(
+    (entry) => entry._aws && entry.Operation === "backfill"
+  );
+  assert.equal(metricLog.PostImageResolutionAttempts, 1);
+  assert.equal(metricLog.PostImageResolutionResolved, 1);
+  assert.equal(metricLog.PostImageResolutionMissing, 0);
+  assert.equal(metricLog.PostImageResolutionErrors, 0);
+});
+
+test("backfillMissingPostImages logs missing and error outcomes without writing unusable thumbnails", async () => {
+  const logger = createLogger();
+  const writes = [];
+  const posts = [
+    {
+      _id: "missing-id",
+      title: "Missing Story",
+      author: "author",
+      created_utc: 1710000000,
+      thumbnail: "",
+      domain: "apnews.com",
+      url: "https://apnews.com/story",
+      sub: "news",
+      is_self: false,
+      is_video: false,
+    },
+    {
+      _id: "error-id",
+      title: "Error Story",
+      author: "author",
+      created_utc: 1710000001,
+      thumbnail: "",
+      domain: "cnn.com",
+      url: "https://cnn.com/story",
+      sub: "news",
+      is_self: false,
+      is_video: false,
+    },
+  ];
+
+  await backfillMissingPostImages("news", {
+    imageSourceImpl: async (post) => {
+      if (post._id === "error-id") {
+        throw new Error("metadata blocked");
+      }
+      return "";
+    },
+    logger,
+    newPostModel: {
+      find: () => ({
+        sort() {
+          return this;
+        },
+        limit() {
+          return this;
+        },
+        then(resolve) {
+          return Promise.resolve(posts).then(resolve);
+        },
+      }),
+      findOneAndUpdate: async (...args) => {
+        writes.push(args);
+      },
+    },
+  });
+
+  assert.equal(writes.length, 0);
+  assert.equal(
+    parseStructuredLogs(logger, "POST_IMAGE_BACKFILL_MISSING").length,
+    2
+  );
+  assert.equal(
+    parseStructuredLogs(logger, "POST_IMAGE_BACKFILL_ERROR").length,
+    1
+  );
+
+  const metricLog = parseStructuredLogs(logger).find((entry) => entry._aws);
+  assert.equal(metricLog.Operation, "backfill");
+  assert.equal(metricLog.PostImageResolutionAttempts, 2);
+  assert.equal(metricLog.PostImageResolutionResolved, 0);
+  assert.equal(metricLog.PostImageResolutionMissing, 2);
+  assert.equal(metricLog.PostImageResolutionErrors, 1);
 });
 
 test("fetchPosts defaults to politics when event has no subreddit", async () => {


### PR DESCRIPTION
## Summary
- promote develop after adding scraper image backfill and image-resolution metrics
- deploy through the normal GitHub Actions main flow

## Validation
- scraper lint passed locally in clean worktree
- scraper tests passed locally in clean worktree: 56/56
- PR checks will run on this main-targeted PR