### PR TITLE
Add scraper image failure diagnostics

### DIFF
--- a/services/scraper/imageSource.js
+++ b/services/scraper/imageSource.js
@@ -342,6 +342,38 @@ const destroyResponseBody = (response) => {
   }
 };
 
+const getHeader = (response, name) => {
+  if (
+    !response ||
+    !response.headers ||
+    typeof response.headers.get !== "function"
+  ) {
+    return "";
+  }
+
+  return response.headers.get(name) || "";
+};
+
+const responseDiagnostics = (response) => ({
+  status: response.status,
+  contentType: getHeader(response, "content-type"),
+  server: getHeader(response, "server"),
+  xCache: getHeader(response, "x-cache"),
+  xDatadome: getHeader(response, "x-datadome"),
+});
+
+const reportArticleImageFailure = (options, failure) => {
+  if (typeof options.onArticleImageFailure !== "function") {
+    return;
+  }
+
+  options.onArticleImageFailure({
+    url: failure.url,
+    reason: failure.reason,
+    ...(failure.details || {}),
+  });
+};
+
 const withTimeout = async (operation, timeoutMs, onTimeout) => {
   let timeout;
 
@@ -374,11 +406,20 @@ const fetchArticleImage = async (url, options = {}) => {
 
   while (redirectCount <= maxRedirects) {
     if (!(await isSafeHttpUrl(nextUrl, { resolveHostname }))) {
+      reportArticleImageFailure(options, {
+        url: nextUrl,
+        reason: "unsafe_url",
+        details: {
+          redirectCount,
+          retryCount: transientRetryCount,
+        },
+      });
       return "";
     }
 
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    let requestTimedOut = false;
 
     try {
       const response = await withTimeout(
@@ -390,7 +431,10 @@ const fetchArticleImage = async (url, options = {}) => {
           timeout: timeoutMs,
         }),
         timeoutMs,
-        () => controller.abort()
+        () => {
+          requestTimedOut = true;
+          controller.abort();
+        }
       );
 
       if (!response) {
@@ -400,6 +444,15 @@ const fetchArticleImage = async (url, options = {}) => {
           transientRetryCount += 1;
           continue;
         }
+        reportArticleImageFailure(options, {
+          url: nextUrl,
+          reason: requestTimedOut ? "request_timeout" : "empty_response",
+          details: {
+            redirectCount,
+            retryCount: transientRetryCount,
+            timeoutMs,
+          },
+        });
         return "";
       }
 
@@ -407,6 +460,15 @@ const fetchArticleImage = async (url, options = {}) => {
         const location = response.headers.get("location");
         if (!location) {
           destroyResponseBody(response);
+          reportArticleImageFailure(options, {
+            url: nextUrl,
+            reason: "redirect_missing_location",
+            details: {
+              ...responseDiagnostics(response),
+              redirectCount,
+              retryCount: transientRetryCount,
+            },
+          });
           return "";
         }
         nextUrl = new URL(location, nextUrl).toString();
@@ -417,43 +479,135 @@ const fetchArticleImage = async (url, options = {}) => {
 
       if (!response.ok) {
         destroyResponseBody(response);
-        if (
+        const canRetry =
           TRANSIENT_RESPONSE_STATUSES.has(response.status) &&
-          canRetryTransientFailure(transientRetryCount, maxTransientRetries)
-        ) {
+          canRetryTransientFailure(transientRetryCount, maxTransientRetries);
+
+        if (canRetry) {
           transientRetryCount += 1;
           continue;
         }
+
+        reportArticleImageFailure(options, {
+          url: nextUrl,
+          reason: "http_status",
+          details: {
+            ...responseDiagnostics(response),
+            redirectCount,
+            retryCount: transientRetryCount,
+          },
+        });
         return "";
       }
 
       const contentType = response.headers.get("content-type") || "";
       if (contentType && !contentType.toLowerCase().includes("text/html")) {
         destroyResponseBody(response);
+        reportArticleImageFailure(options, {
+          url: nextUrl,
+          reason: "non_html_response",
+          details: {
+            ...responseDiagnostics(response),
+            redirectCount,
+            retryCount: transientRetryCount,
+          },
+        });
         return "";
       }
 
-      const html = await withTimeout(
-        readResponseBody(response, maxBytes),
-        timeoutMs,
-        () => controller.abort()
-      );
+      let htmlTimedOut = false;
+      let html;
+
+      try {
+        html = await withTimeout(
+          readResponseBody(response, maxBytes),
+          timeoutMs,
+          () => {
+            htmlTimedOut = true;
+            controller.abort();
+          }
+        );
+      } catch (error) {
+        if (
+          canRetryTransientFailure(transientRetryCount, maxTransientRetries)
+        ) {
+          transientRetryCount += 1;
+          continue;
+        }
+        reportArticleImageFailure(options, {
+          url: nextUrl,
+          reason: "body_read_error",
+          details: {
+            ...responseDiagnostics(response),
+            redirectCount,
+            retryCount: transientRetryCount,
+            errorName: error.name,
+            errorMessage: error.message,
+          },
+        });
+        return "";
+      }
+
       if (!html) {
+        reportArticleImageFailure(options, {
+          url: nextUrl,
+          reason: htmlTimedOut ? "body_read_timeout" : "empty_html",
+          details: {
+            ...responseDiagnostics(response),
+            redirectCount,
+            retryCount: transientRetryCount,
+            timeoutMs,
+          },
+        });
         return "";
       }
 
-      return extractMetaImage(html, nextUrl);
+      const image = extractMetaImage(html, nextUrl);
+      if (!image) {
+        reportArticleImageFailure(options, {
+          url: nextUrl,
+          reason: "no_meta_image",
+          details: {
+            ...responseDiagnostics(response),
+            redirectCount,
+            retryCount: transientRetryCount,
+            bytesRead: Buffer.byteLength(html),
+          },
+        });
+        return "";
+      }
+
+      return image;
     } catch (error) {
       if (canRetryTransientFailure(transientRetryCount, maxTransientRetries)) {
         transientRetryCount += 1;
         continue;
       }
+      reportArticleImageFailure(options, {
+        url: nextUrl,
+        reason: "fetch_error",
+        details: {
+          redirectCount,
+          retryCount: transientRetryCount,
+          errorName: error.name,
+          errorMessage: error.message,
+        },
+      });
       return "";
     } finally {
       clearTimeout(timeout);
     }
   }
 
+  reportArticleImageFailure(options, {
+    url: nextUrl,
+    reason: "too_many_redirects",
+    details: {
+      redirectCount,
+      retryCount: transientRetryCount,
+      maxRedirects,
+    },
+  });
   return "";
 };
 

--- a/services/scraper/imageSource.test.js
+++ b/services/scraper/imageSource.test.js
@@ -62,8 +62,10 @@ test("extractMetaImage ignores unusable image URLs", () => {
 
 test("fetchArticleImage rejects private network URLs before fetching", async () => {
   let fetchCalled = false;
+  const failures = [];
 
   const image = await fetchArticleImage("http://127.0.0.1/article", {
+    onArticleImageFailure: (failure) => failures.push(failure),
     fetchImpl: async () => {
       fetchCalled = true;
     },
@@ -71,6 +73,14 @@ test("fetchArticleImage rejects private network URLs before fetching", async () 
 
   assert.equal(image, "");
   assert.equal(fetchCalled, false);
+  assert.deepEqual(failures, [
+    {
+      url: "http://127.0.0.1/article",
+      reason: "unsafe_url",
+      redirectCount: 0,
+      retryCount: 0,
+    },
+  ]);
 });
 
 test("isSafeHttpUrl rejects malformed, localhost, private IPv6, and DNS failures", async () => {
@@ -234,6 +244,43 @@ test("fetchArticleImage retries transient publisher denials once", async () => {
   assert.equal(deniedBodyDestroyed, true);
 });
 
+test("fetchArticleImage reports blocked publisher response details", async () => {
+  const failures = [];
+
+  const image = await fetchArticleImage("https://publisher.example/story", {
+    resolveHostname: async () => [{ address: "93.184.216.34", family: 4 }],
+    onArticleImageFailure: (failure) => failures.push(failure),
+    fetchImpl: async () => ({
+      ok: false,
+      status: 401,
+      headers: createHeaders({
+        "content-type": "text/html;charset=utf-8",
+        server: "CloudFront",
+        "x-cache": "LambdaGeneratedResponse from cloudfront",
+        "x-datadome": "protected",
+      }),
+      body: {
+        destroy: () => {},
+      },
+    }),
+  });
+
+  assert.equal(image, "");
+  assert.deepEqual(failures, [
+    {
+      url: "https://publisher.example/story",
+      reason: "http_status",
+      status: 401,
+      contentType: "text/html;charset=utf-8",
+      server: "CloudFront",
+      xCache: "LambdaGeneratedResponse from cloudfront",
+      xDatadome: "protected",
+      redirectCount: 0,
+      retryCount: 0,
+    },
+  ]);
+});
+
 test("fetchArticleImage retries transient fetch failures once", async () => {
   let requestCount = 0;
 
@@ -356,6 +403,40 @@ test("fetchArticleImage returns empty when article HTML is empty", async () => {
   });
 
   assert.equal(image, "");
+});
+
+test("fetchArticleImage reports when article HTML has no image metadata", async () => {
+  const failures = [];
+
+  const image = await fetchArticleImage("https://publisher.example/story", {
+    resolveHostname: async () => [{ address: "93.184.216.34", family: 4 }],
+    onArticleImageFailure: (failure) => failures.push(failure),
+    fetchImpl: async () => ({
+      ok: true,
+      status: 200,
+      headers: createHeaders({
+        "content-type": "text/html; charset=utf-8",
+        server: "publisher",
+      }),
+      text: async () => "<html><head><title>No image</title></head></html>",
+    }),
+  });
+
+  assert.equal(image, "");
+  assert.deepEqual(failures, [
+    {
+      url: "https://publisher.example/story",
+      reason: "no_meta_image",
+      status: 200,
+      contentType: "text/html; charset=utf-8",
+      server: "publisher",
+      xCache: "",
+      xDatadome: "",
+      redirectCount: 0,
+      retryCount: 0,
+      bytesRead: 49,
+    },
+  ]);
 });
 
 test("fetchArticleImage returns empty when fetch rejects", async () => {

--- a/services/scraper/index.js
+++ b/services/scraper/index.js
@@ -40,6 +40,29 @@ const logStructured = (logger, payload) => {
   logger.log(JSON.stringify(payload));
 };
 
+const createImageFailureDiagnostics = () => {
+  const failures = [];
+
+  return {
+    failures,
+    options: {
+      onArticleImageFailure: (failure) => {
+        failures.push(failure);
+      },
+    },
+  };
+};
+
+const imageFailureLogFields = (diagnostics) => {
+  if (!diagnostics.failures.length) {
+    return {};
+  }
+
+  return {
+    imageResolutionFailures: diagnostics.failures.slice(-3),
+  };
+};
+
 const createImageResolutionMetrics = (subreddit, operation) => ({
   subreddit,
   operation,
@@ -172,9 +195,10 @@ const backfillMissingPostImages = async (
 
       imageMetrics.attempts += 1;
       let thumbnail = "";
+      const diagnostics = createImageFailureDiagnostics();
 
       try {
-        thumbnail = await imageSourceImpl(post);
+        thumbnail = await imageSourceImpl(post, diagnostics.options);
       } catch (error) {
         imageMetrics.errors += 1;
         logStructured(logger, {
@@ -185,6 +209,7 @@ const backfillMissingPostImages = async (
           postUrl: getPostUrl(post),
           title: post.title,
           errorMessage: error.message,
+          ...imageFailureLogFields(diagnostics),
         });
       }
 
@@ -211,6 +236,7 @@ const backfillMissingPostImages = async (
         postUrl: getPostUrl(post),
         title: post.title,
         redditThumbnail: post.thumbnail || "",
+        ...imageFailureLogFields(diagnostics),
       });
     }
   );
@@ -266,8 +292,9 @@ const insertNewPosts = (
       await newPostModel.findOneAndUpdate(postKey, postUpdate, { upsert: true });
 
       let thumbnail = value.data.thumbnail || "";
+      const diagnostics = createImageFailureDiagnostics();
       try {
-        thumbnail = await imageSourceImpl(value.data);
+        thumbnail = await imageSourceImpl(value.data, diagnostics.options);
       } catch (error) {
         if (trackImageResolution) {
           imageMetrics.errors += 1;
@@ -279,6 +306,7 @@ const insertNewPosts = (
             postUrl: getPostUrl(value.data),
             title: value.data.title,
             errorMessage: error.message,
+            ...imageFailureLogFields(diagnostics),
           });
         }
         logger.warn(
@@ -305,6 +333,7 @@ const insertNewPosts = (
           postUrl: getPostUrl(value.data),
           title: value.data.title,
           redditThumbnail: value.data.thumbnail || "",
+          ...imageFailureLogFields(diagnostics),
         });
       }
 
@@ -429,6 +458,7 @@ const createFetchPosts = ({
 module.exports.createFetchPosts = createFetchPosts;
 module.exports.createImageResolutionMetrics = createImageResolutionMetrics;
 module.exports.backfillMissingPostImages = backfillMissingPostImages;
+module.exports.createImageFailureDiagnostics = createImageFailureDiagnostics;
 module.exports.findMissingThumbnailPosts = findMissingThumbnailPosts;
 module.exports.fetchPosts = createFetchPosts();
 module.exports.logImageResolutionMetrics = logImageResolutionMetrics;

--- a/services/scraper/index.test.js
+++ b/services/scraper/index.test.js
@@ -425,6 +425,78 @@ test("fetchPosts logs missing article image metrics for graphing", async () => {
   );
 });
 
+test("fetchPosts includes article image failure details in missing logs", async () => {
+  const posts = [
+    {
+      data: {
+        id: "post1",
+        title: "Reuters Story",
+        author: "author",
+        created_utc: 1710000000,
+        thumbnail: "",
+        domain: "reuters.com",
+        url: "https://www.reuters.com/world/story",
+        permalink: "/r/news/comments/story",
+        ups: 42,
+        num_comments: 7,
+        post_hint: "link",
+        is_video: false,
+        media: null,
+        is_gallery: false,
+        gallery_data: null,
+        media_metadata: null,
+        is_self: false,
+        selftext: "",
+        selftext_html: null,
+        upvote_ratio: 0.91,
+        rpan_video: null,
+      },
+    },
+  ];
+  const { fetchImpl } = createFetcher({ posts });
+  const logger = createLogger();
+  const handler = createFetchPosts({
+    fetchImpl,
+    imageSourceImpl: async (post, options) => {
+      options.onArticleImageFailure({
+        url: post.url,
+        reason: "http_status",
+        status: 401,
+        contentType: "text/html;charset=utf-8",
+        server: "CloudFront",
+        xDatadome: "protected",
+        retryCount: 0,
+      });
+      return "";
+    },
+    logger,
+    mongooseClient: {
+      connect: async () => {},
+    },
+    newPostModel: {
+      findOneAndUpdate: async () => {},
+    },
+  });
+
+  await handler({ subreddit: "news" });
+
+  const [missingLog] = parseStructuredLogs(
+    logger,
+    "POST_IMAGE_RESOLUTION_MISSING"
+  );
+  assert.deepEqual(missingLog.imageResolutionFailures, [
+    {
+      url: "https://www.reuters.com/world/story",
+      reason: "http_status",
+      status: 401,
+      contentType: "text/html;charset=utf-8",
+      server: "CloudFront",
+      xDatadome: "protected",
+      retryCount: 0,
+    },
+  ]);
+});
+
 test("fetchPosts logs image resolution errors separately from missing thumbnails", async () => {
   const posts = [
     {
@@ -626,10 +698,16 @@ test("backfillMissingPostImages logs missing and error outcomes without writing 
   ];
 
   await backfillMissingPostImages("news", {
-    imageSourceImpl: async (post) => {
+    imageSourceImpl: async (post, options) => {
       if (post._id === "error-id") {
         throw new Error("metadata blocked");
       }
+      options.onArticleImageFailure({
+        url: post.url,
+        reason: "no_meta_image",
+        status: 200,
+        contentType: "text/html",
+      });
       return "";
     },
     logger,
@@ -655,6 +733,18 @@ test("backfillMissingPostImages logs missing and error outcomes without writing 
   assert.equal(
     parseStructuredLogs(logger, "POST_IMAGE_BACKFILL_MISSING").length,
     2
+  );
+  assert.deepEqual(
+    parseStructuredLogs(logger, "POST_IMAGE_BACKFILL_MISSING")[0]
+      .imageResolutionFailures,
+    [
+      {
+        url: "https://apnews.com/story",
+        reason: "no_meta_image",
+        status: 200,
+        contentType: "text/html",
+      },
+    ]
   );
   assert.equal(
     parseStructuredLogs(logger, "POST_IMAGE_BACKFILL_ERROR").length,


### PR DESCRIPTION
## Summary
- add bounded failure diagnostics to fetchArticleImage without changing its URL-or-empty return contract
- include imageResolutionFailures on POST_IMAGE_RESOLUTION_MISSING and POST_IMAGE_BACKFILL_MISSING logs
- avoid logging response bodies or cookies; only reason/status/content-type/server/x-cache/x-datadome/retry metadata

## Validation
- services/scraper: npm run lint
- services/scraper: npm test (59/59)

## Deploy path
PR to develop first; promote develop to main after checks pass so GitHub Actions owns production deploy.