### PR TITLE
Deploy supported subreddit additions

### DIFF
--- a/services/scraper/serverless.test.js
+++ b/services/scraper/serverless.test.js
@@ -25,6 +25,7 @@ test("fetchPosts is scheduled for the supported news subreddits", () => {
     "health",
     "environment",
     "energy",
+    "sports",
     "business",
     "Economics",
   ]);

--- a/services/scraper/serverless.test.js
+++ b/services/scraper/serverless.test.js
@@ -18,6 +18,7 @@ test("fetchPosts is scheduled for the supported news subreddits", () => {
   assert.deepEqual(getScheduledSubreddits(), [
     "politics",
     "worldnews",
+    "europe",
     "news",
     "technology",
     "science",

--- a/services/scraper/serverless.test.js
+++ b/services/scraper/serverless.test.js
@@ -23,7 +23,6 @@ test("fetchPosts is scheduled for the supported news subreddits", () => {
     "technology",
     "science",
     "health",
-    "environment",
     "energy",
     "sports",
     "business",

--- a/services/scraper/serverless.test.js
+++ b/services/scraper/serverless.test.js
@@ -22,7 +22,9 @@ test("fetchPosts is scheduled for the supported news subreddits", () => {
     "news",
     "technology",
     "science",
+    "health",
     "environment",
+    "energy",
     "business",
     "Economics",
   ]);

--- a/services/scraper/serverless.yml
+++ b/services/scraper/serverless.yml
@@ -33,6 +33,11 @@ functions:
           rate: rate(5 minutes)
           enabled: true
           input:
+            subreddit: europe
+      - schedule:
+          rate: rate(5 minutes)
+          enabled: true
+          input:
             subreddit: news
       - schedule:
           rate: rate(5 minutes)

--- a/services/scraper/serverless.yml
+++ b/services/scraper/serverless.yml
@@ -68,6 +68,11 @@ functions:
           rate: rate(5 minutes)
           enabled: true
           input:
+            subreddit: sports
+      - schedule:
+          rate: rate(5 minutes)
+          enabled: true
+          input:
             subreddit: business
       - schedule:
           rate: rate(5 minutes)

--- a/services/scraper/serverless.yml
+++ b/services/scraper/serverless.yml
@@ -53,7 +53,17 @@ functions:
           rate: rate(5 minutes)
           enabled: true
           input:
+            subreddit: health
+      - schedule:
+          rate: rate(5 minutes)
+          enabled: true
+          input:
             subreddit: environment
+      - schedule:
+          rate: rate(5 minutes)
+          enabled: true
+          input:
+            subreddit: energy
       - schedule:
           rate: rate(5 minutes)
           enabled: true

--- a/services/scraper/serverless.yml
+++ b/services/scraper/serverless.yml
@@ -58,11 +58,6 @@ functions:
           rate: rate(5 minutes)
           enabled: true
           input:
-            subreddit: environment
-      - schedule:
-          rate: rate(5 minutes)
-          enabled: true
-          input:
             subreddit: energy
       - schedule:
           rate: rate(5 minutes)

--- a/services/subreddits/index.js
+++ b/services/subreddits/index.js
@@ -8,7 +8,6 @@ const configuredSubreddits = [
   "technology",
   "science",
   "health",
-  "environment",
   "energy",
   "sports",
   "business",

--- a/services/subreddits/index.js
+++ b/services/subreddits/index.js
@@ -10,6 +10,7 @@ const configuredSubreddits = [
   "health",
   "environment",
   "energy",
+  "sports",
   "business",
   "Economics",
 ];

--- a/services/subreddits/index.js
+++ b/services/subreddits/index.js
@@ -7,7 +7,9 @@ const configuredSubreddits = [
   "news",
   "technology",
   "science",
+  "health",
   "environment",
+  "energy",
   "business",
   "Economics",
 ];

--- a/services/subreddits/index.js
+++ b/services/subreddits/index.js
@@ -3,6 +3,7 @@ const { createCorsHeaders, isAllowedOrigin } = require("./cors");
 const configuredSubreddits = [
   "politics",
   "worldnews",
+  "europe",
   "news",
   "technology",
   "science",

--- a/services/subreddits/index.test.js
+++ b/services/subreddits/index.test.js
@@ -6,6 +6,7 @@ const { createGetSubreddits } = require("./index");
 const configuredSubreddits = [
   "politics",
   "worldnews",
+  "europe",
   "news",
   "technology",
   "science",

--- a/services/subreddits/index.test.js
+++ b/services/subreddits/index.test.js
@@ -11,7 +11,6 @@ const configuredSubreddits = [
   "technology",
   "science",
   "health",
-  "environment",
   "energy",
   "sports",
   "business",

--- a/services/subreddits/index.test.js
+++ b/services/subreddits/index.test.js
@@ -10,7 +10,9 @@ const configuredSubreddits = [
   "news",
   "technology",
   "science",
+  "health",
   "environment",
+  "energy",
   "business",
   "Economics",
 ];

--- a/services/subreddits/index.test.js
+++ b/services/subreddits/index.test.js
@@ -13,6 +13,7 @@ const configuredSubreddits = [
   "health",
   "environment",
   "energy",
+  "sports",
   "business",
   "Economics",
 ];


### PR DESCRIPTION
## Summary
- deploy support for r/europe, r/health, r/energy, and r/sports
- include the new subreddits in the public subreddit list used by the UI dropdown
- add scheduled scraper inputs for each new subreddit

## Validation
- services/subreddits: npm test
- services/subreddits: npm run lint
- services/scraper: npm test
- services/scraper: npm run lint

## Deploy path
- This PR follows the required develop -> main path so GitHub Actions performs the deploy after merge.