### PR TITLE
Refresh posts when returning to stale tab

### DIFF
--- a/webui/src/Components/MainContent.jsx
+++ b/webui/src/Components/MainContent.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useState, useEffect, useContext, useRef } from 'react';
 import {
   Container,
   useBreakpointValue,
@@ -31,6 +31,7 @@ const SCRAPER_REFRESH_INTERVAL_MS = 1000 * 60 * 5;
 const SCRAPER_FRESHNESS_GRACE_MS = 1000 * 60 * 2;
 const STALE_POSTS_THRESHOLD_MS =
   SCRAPER_REFRESH_INTERVAL_MS + SCRAPER_FRESHNESS_GRACE_MS;
+const MIN_RESUME_REFRESH_AGE_MS = 1000 * 30;
 
 const isOlderThanExpectedScraperWindow = date => {
   const latestExpectedFetch = Date.now() - STALE_POSTS_THRESHOLD_MS;
@@ -99,6 +100,7 @@ const PostView = () => {
 
   const [posts, setPosts] = useState([]);
   const [hasLoadedPosts, setHasLoadedPosts] = useState(false);
+  const lastFetchStartedAtRef = useRef(0);
   const [error, setError] = useState({
     level: 'warning',
     show: false,
@@ -115,6 +117,7 @@ const PostView = () => {
   });
 
   const fetchPosts = () => {
+    lastFetchStartedAtRef.current = Date.now();
     setLoading(true);
     fetch(getPostsUrl(subreddit))
       .then(response => {
@@ -162,6 +165,35 @@ const PostView = () => {
       }
     }
   }, [refreshInterval, subreddit, isVisible]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (!refreshInterval || refreshInterval <= 0) {
+      return undefined;
+    }
+
+    const refreshPostsAfterResume = () => {
+      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+        return;
+      }
+
+      const refreshAgeMs = Math.max(
+        Number(refreshInterval) * 1000,
+        MIN_RESUME_REFRESH_AGE_MS
+      );
+
+      if (Date.now() - lastFetchStartedAtRef.current >= refreshAgeMs) {
+        fetchPosts();
+      }
+    };
+
+    window.addEventListener('focus', refreshPostsAfterResume);
+    window.addEventListener('pageshow', refreshPostsAfterResume);
+
+    return () => {
+      window.removeEventListener('focus', refreshPostsAfterResume);
+      window.removeEventListener('pageshow', refreshPostsAfterResume);
+    };
+  }, [refreshInterval, subreddit]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <Container maxW={maxW} mt={16} pl={padding} pr={padding}>

--- a/webui/src/Components/MainContent.test.jsx
+++ b/webui/src/Components/MainContent.test.jsx
@@ -13,11 +13,11 @@ Object.defineProperty(window, 'matchMedia', {
   value: matchMedia,
 });
 
-const renderMainContent = () =>
+const renderMainContent = ({ refreshInterval = 1 } = {}) =>
   render(
     <LoadingContext.Provider value={{ loading: false, setLoading: vi.fn() }}>
       <RefreshIntervalContext.Provider
-        value={{ refreshInterval: 1, setRefreshInterval: vi.fn() }}
+        value={{ refreshInterval, setRefreshInterval: vi.fn() }}
       >
         <SubredditContext.Provider
           value={{
@@ -278,5 +278,59 @@ describe('MainContent', () => {
     expect(global.fetch).toHaveBeenCalledTimes(2);
 
     consoleErrorSpy.mockRestore();
+  });
+
+  test('refreshes posts when a stale suspended tab receives focus', async () => {
+    const stalePost = {
+      title: 'Before laptop sleep headline',
+      url: 'https://example.com/before',
+      commentCount: 12,
+      upvoteCount: 42,
+      created_utc: Math.floor(Date.now() / 1000),
+      domain: 'example.com',
+      commentLink: '/r/politics/comments/before/example',
+    };
+    const freshPost = {
+      title: 'After laptop wake headline',
+      url: 'https://example.com/after',
+      commentCount: 24,
+      upvoteCount: 84,
+      created_utc: Math.floor(Date.now() / 1000),
+      domain: 'example.com',
+      commentLink: '/r/politics/comments/after/example',
+    };
+
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: [stalePost] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: [freshPost] }),
+      });
+
+    await act(async () => {
+      renderMainContent({ refreshInterval: 600 });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Before laptop sleep headline')).toBeInTheDocument();
+
+    vi.setSystemTime(new Date('2026-06-06T12:11:00.000Z'));
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('After laptop wake headline')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Before laptop sleep headline')).not.toBeInTheDocument();
+    expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
- Refresh posts on guarded browser resume events, focus and pageshow, when the last fetch is older than the configured refresh interval.
- Keep the existing interval and page-visibility refresh behavior.
- Add regression coverage for a suspended tab returning after stale data.

## Validation
- webui: npm test -- MainContent.test.jsx
- webui: npm run lint
- webui: CI=true npm test -- --watchAll=false
