### PR TITLE
Link story images to Reddit comments

### DIFF
--- a/webui/src/Components/PostCard.jsx
+++ b/webui/src/Components/PostCard.jsx
@@ -271,7 +271,17 @@ export const PostCard = ({post, elId}) => {
         transform: 'translateY(-1px)',
       }}
     >
-      <Box position='relative' bg={mediaBg}>
+      <Box
+        as={Link}
+        href={redditUrl}
+        isExternal
+        position='relative'
+        bg={mediaBg}
+        display='block'
+        aria-label={`Open Reddit comments for ${title}`}
+        _hover={{ textDecoration: 'none' }}
+        onClick={() => trackSelection('reddit_comments')}
+      >
         <Image
           src={getThumbnailSrc(post.thumbnail)}
           w='100%'

--- a/webui/src/Components/PostCard.test.jsx
+++ b/webui/src/Components/PostCard.test.jsx
@@ -97,9 +97,12 @@ describe('PostCard', () => {
 
   test('tracks article and Reddit content selections', () => {
     renderPostCard(vi.fn());
+    const redditLinks = screen.getAllByRole('link', {
+      name: /open reddit comments for existing headline/i,
+    });
 
     fireEvent.click(screen.getByRole('link', { name: 'Existing headline' }));
-    fireEvent.click(screen.getAllByRole('link', { name: /open reddit comments/i }).at(-1));
+    fireEvent.click(redditLinks.at(-1));
 
     expect(trackPostSelection).toHaveBeenCalledWith({
       contentType: 'article',
@@ -108,6 +111,27 @@ describe('PostCard', () => {
       subreddit: 'politics',
       viewMode: 'grid',
     });
+    expect(trackPostSelection).toHaveBeenCalledWith({
+      contentType: 'reddit_comments',
+      post,
+      position: 1,
+      subreddit: 'politics',
+      viewMode: 'grid',
+    });
+  });
+
+  test('links the story image to Reddit comments', () => {
+    renderPostCard(vi.fn());
+
+    const redditUrl = `https://reddit.com${post.commentLink}`;
+    const redditLinks = screen.getAllByRole('link', {
+      name: /open reddit comments for existing headline/i,
+    });
+
+    expect(redditLinks[0]).toHaveAttribute('href', redditUrl);
+
+    fireEvent.click(redditLinks[0]);
+
     expect(trackPostSelection).toHaveBeenCalledWith({
       contentType: 'reddit_comments',
       post,


### PR DESCRIPTION
## Summary
- Make the story thumbnail/media area link to the Reddit comments page.
- Track image clicks as reddit_comments selections, matching the existing comments links.
- Keep the explicit Preview button for media posts.

## Validation
- webui: npm test -- PostCard.test.jsx
- webui: npm run lint
- webui: CI=true npm test -- --watchAll=false
